### PR TITLE
Disables one-var linting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 module.exports = {
   "extends": "standard",
   "plugins": [
-      "standard",
-      "promise"
+    "standard",
+    "promise"
   ],
   "rules": {
     "camelcase": 0,
     "new-cap": 0,
-    "one-var": ["error", "always"],
+    "one-var": ["error", "never"],
     "semi": ["error", "always"],
     "space-before-function-paren": 0
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ndustrial",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Common eslint configuration for all of ndustrial.io's node applications",
   "keywords": ["eslint", "eslintconfig"],
   "main": "index.js",


### PR DESCRIPTION
# Why?
Disabling the `one-var` rule. I often like to write out constants on separate lines, e.g.:

```
const foo = { bar: 'baz' };
const item = something.getSomething();
```

The `one-var` rule requires you to do variable declarations all in one statement, which I think is more difficult to read.

