### PR TITLE
Remove peer dependencies from regular dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,23 @@ Common eslint configuration for all of ndustrial.io's node applications
 ## Installation
 You can install this module through the regular NPM repository by using the snippet below:
 ```
-npm install --save-dev eslint-config-ndustrial
-```
-
-or by adding this line to `devDependencies` in your `package.json` file.
-```
-  "eslint-config-ndustrial": "^1.0.0",
+npm install --save-dev eslint-config-ndustrial eslint eslint-config-standard eslint-plugin-import eslint-plugin-node eslint-plugin-promise eslint-plugin-standard
 ```
 
 Once that is installed, create an `.eslintrc.json` file in your root directory and add the following line:
 
 ```
-{ "extends": "ndustrial"}
+{ "extends": "ndustrial" }
 ```
 
-From there, you can run eslint in your terminal with the command `eslint **/*.js`, or add that line to your package.json scripts as shown below:
+From there, you can run eslint in your terminal with the command `eslint '**/*.js'`, or add that line to your package.json scripts as shown below:
 
 ```
 "scripts": {
-    "start": "./node_modules/.bin/nodemon server.js",
-    "test": "npm run lint",
-    "lint": "eslint **/*.js"
-  }
+  "start": "./node_modules/.bin/nodemon server.js",
+  "test": "npm run lint",
+  "lint": "eslint '**/*.js'"
+}
 ```
 
 Once it is added to your `package.json` file, you can just run `npm run lint`.

--- a/package.json
+++ b/package.json
@@ -20,12 +20,5 @@
     "eslint-plugin-import": ">=2.2.0",
     "eslint-plugin-promise": ">=3.5.0",
     "eslint-plugin-standard": ">=2.1.1"
-  },
-  "dependencies": {
-    "eslint": ">= 3",
-    "eslint-config-standard": ">=7.0.0",
-    "eslint-plugin-import": ">=2.2.0",
-    "eslint-plugin-promise": ">=3.5.0",
-    "eslint-plugin-standard": ">=2.1.1"
   }
 }


### PR DESCRIPTION
## Why?
It defeats the purpose of peer dependencies to also list them as regular dependencies.

## What changed?
- Removed peer dependencies from the regular dependencies
- Updated documentation to reflect peer dependencies