### PR TITLE
Set config to prefer const over let

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
     "new-cap": 0,
     "one-var": ["error", "never"],
     "semi": ["error", "always"],
-    "space-before-function-paren": 0
+    "space-before-function-paren": 0,
+    "prefer-const": "error"
   }
 };


### PR DESCRIPTION
## Why?
>If a variable is never reassigned, using the const declaration is better.
>
>const declaration tells readers, “this variable is never reassigned,” reducing cognitive load and improving maintainability.

(source: https://eslint.org/docs/rules/prefer-const)

## What changed?
- Started preferring `const` over `let`